### PR TITLE
Fix min/max time external update usage

### DIFF
--- a/addon/components/power-time-picker.js
+++ b/addon/components/power-time-picker.js
@@ -8,10 +8,16 @@ import { scheduler } from 'ember-raf-scheduler';
 
 export default class PowerTimePicker extends Component {
   @tracked steps = this.args.steps ?? 5;
-  @tracked minTime = this.args.minTime ?? '06:00';
-  @tracked maxTime = this.args.maxTime ?? '22:00';
   @tracked triggerComponent = this.args.triggerComponent ?? 'power-time-picker/trigger';
   @tracked optionsComponent = this.args.optionsComponent ?? 'power-time-picker/options';
+
+  get minTime() {
+    return this.args.minTime ?? '06:00';
+  }
+
+  get maxTime() {
+    return this.args.maxTime ?? '22:00';
+  }
 
   get options() {
     let options = [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lan0/ember-power-time-picker",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lan0/ember-power-time-picker",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@ember-decorators/component": "^6.0.0",

--- a/tests/integration/components/power-time-picker-test.js
+++ b/tests/integration/components/power-time-picker-test.js
@@ -238,4 +238,32 @@ module('Integration | Component | power-time-picker', function(hooks) {
     await click('.ember-power-select-option');
     assert.equal(document.querySelector('.ember-power-select-search-input').value, '13:15', 'the input gets set to selected value');
   });
+
+  test('picker updates if min/max value has been updated externally', async function (assert) {
+    this.minTime = "10:00";
+    this.maxTime = "12:00"
+    await render(hbs`
+      <PowerTimePicker @minTime={{this.minTime}} @steps={{30}} @maxTime={{this.maxTime}} @selected="11:00" @onChange={{fn (mut this.time)}} as |time|>
+        {{time}}
+      </PowerTimePicker>
+    `);
+
+    await click('.ember-power-select-search-input');
+
+    let options = document.querySelectorAll('.ember-power-select-option');
+
+    assert.equal(options[0].textContent.trim(), '10:00');
+    assert.equal(options[options.length - 1].textContent.trim(), '12:00');
+
+    await click('.ember-power-select-search-input');
+
+    this.set('minTime', '11:00');
+    this.set('maxTime', '13:00')
+
+    await click('.ember-power-select-search-input');
+
+    options = document.querySelectorAll('.ember-power-select-option');
+    assert.equal(options[0].textContent.trim(), '11:00');
+    assert.equal(options[options.length - 1].textContent.trim(), '13:00');
+  })
 });

--- a/tests/integration/components/power-time-picker-test.js
+++ b/tests/integration/components/power-time-picker-test.js
@@ -9,7 +9,7 @@ module('Integration | Component | power-time-picker', function(hooks) {
 
   test('it highlights selected time on open', async function(assert) {
     await render(hbs`
-      <PowerTimePicker @selected="06:30" @onChange={{fn (mut time)}} as |time|>
+      <PowerTimePicker @selected="06:30" @onChange={{fn (mut this.time)}} as |time|>
         {{time}}
       </PowerTimePicker>
     `);
@@ -30,7 +30,7 @@ module('Integration | Component | power-time-picker', function(hooks) {
 
   test('it can set minute steps', async function(assert) {
     await render(hbs`
-      <PowerTimePicker @steps=15 @selected="12:00" @onChange={{fn (mut time)}} as |time|>
+      <PowerTimePicker @steps={{15}} @selected="12:00" @onChange={{fn (mut this.time)}} as |time|>
         {{time}}
       </PowerTimePicker>
     `);
@@ -46,7 +46,7 @@ module('Integration | Component | power-time-picker', function(hooks) {
 
   test('it allows invalid minute steps', async function(assert) {
     await render(hbs`
-      <PowerTimePicker @steps={{null}} @onChange={{fn (mut time)}} as |time|>
+      <PowerTimePicker @steps={{null}} @onChange={{fn (mut this.time)}} as |time|>
         {{time}}
       </PowerTimePicker>
     `);
@@ -60,7 +60,7 @@ module('Integration | Component | power-time-picker', function(hooks) {
 
   test('it can set min and max time', async function(assert) {
     await render(hbs`
-      <PowerTimePicker @minTime="12:00" @maxTime="13:00" @selected="12:00" @onChange={{fn (mut time)}} as |time|>
+      <PowerTimePicker @minTime="12:00" @maxTime="13:00" @selected="12:00" @onChange={{fn (mut this.time)}} as |time|>
         {{time}}
       </PowerTimePicker>
     `);
@@ -89,7 +89,7 @@ module('Integration | Component | power-time-picker', function(hooks) {
 
   test('it adds selected as option', async function(assert) {
     await render(hbs`
-      <PowerTimePicker @selected="05:00" @steps=15 @onChange={{fn (mut time)}} as |time|>
+      <PowerTimePicker @selected="05:00" @steps={{15}} @onChange={{fn (mut this.time)}} as |time|>
         {{time}}
       </PowerTimePicker>
     `);
@@ -101,7 +101,7 @@ module('Integration | Component | power-time-picker', function(hooks) {
 
   test('it does not duplicate selected item', async function(assert) {
     await render(hbs`
-      <PowerTimePicker @selected="06:00" @steps=15 @onChange={{fn (mut time)}} as |time|>
+      <PowerTimePicker @selected="06:00" @steps={{15}} @onChange={{fn (mut this.time)}} as |time|>
         {{time}}
       </PowerTimePicker>
     `);
@@ -116,7 +116,7 @@ module('Integration | Component | power-time-picker', function(hooks) {
 
   test('it highlights time on search', async function(assert) {
     await render(hbs`
-      <PowerTimePicker @selected="06:00" @steps=15 @onChange={{fn (mut time)}} as |time|>
+      <PowerTimePicker @selected="06:00" @steps={{15}} @onChange={{fn (mut this.time)}} as |time|>
         {{time}}
       </PowerTimePicker>
     `);
@@ -131,7 +131,7 @@ module('Integration | Component | power-time-picker', function(hooks) {
 
   test('it supports search with colons omitted', async function(assert) {
     await render(hbs`
-      <PowerTimePicker @selected="06:00" @steps=15 @onChange={{fn (mut time)}} as |time|>
+      <PowerTimePicker @selected="06:00" @steps={{15}} @onChange={{fn (mut this.time)}} as |time|>
         {{time}}
       </PowerTimePicker>
     `);
@@ -146,7 +146,7 @@ module('Integration | Component | power-time-picker', function(hooks) {
 
   test('it highlights nearest match', async function(assert) {
     await render(hbs`
-      <PowerTimePicker @selected="06:00" @steps=15 @onChange={{fn (mut time)}} as |time|>
+      <PowerTimePicker @selected="06:00" @steps={{15}} @onChange={{fn (mut this.time)}} as |time|>
         {{time}}
       </PowerTimePicker>
     `);
@@ -161,7 +161,7 @@ module('Integration | Component | power-time-picker', function(hooks) {
 
   test('it allows leading 0 to be omitted', async function(assert) {
     await render(hbs`
-      <PowerTimePicker @selected="06:00" @steps=15 @onChange={{fn (mut time)}} as |time|>
+      <PowerTimePicker @selected="06:00" @steps={{15}} @onChange={{fn (mut this.time)}} as |time|>
         {{time}}
       </PowerTimePicker>
     `);
@@ -176,7 +176,7 @@ module('Integration | Component | power-time-picker', function(hooks) {
 
   test('it allows last number to be omitted', async function(assert) {
     await render(hbs`
-      <PowerTimePicker @selected="06:00" @steps=15 @onChange={{fn (mut time)}} as |time|>
+      <PowerTimePicker @selected="06:00" @steps={{15}} @onChange={{fn (mut this.time)}} as |time|>
         {{time}}
       </PowerTimePicker>
     `);
@@ -190,7 +190,7 @@ module('Integration | Component | power-time-picker', function(hooks) {
 
   test('it allows leading zero in fuzzy search', async function(assert) {
     await render(hbs`
-      <PowerTimePicker @selected="06:00" @steps=15 @onChange={{fn (mut time)}} as |time|>
+      <PowerTimePicker @selected="06:00" @steps={{15}} @onChange={{fn (mut this.time)}} as |time|>
         {{time}}
       </PowerTimePicker>
     `);
@@ -204,7 +204,7 @@ module('Integration | Component | power-time-picker', function(hooks) {
 
   test('it fills out search input with selected value', async function(assert) {
     await render(hbs`
-      <PowerTimePicker @selected={{this.time}} @steps=15 @onChange={{fn (mut time)}} as |time|>
+      <PowerTimePicker @selected={{this.time}} @steps={{15}} @onChange={{fn (mut this.time)}} as |time|>
         {{time}}
       </PowerTimePicker>
     `);
@@ -216,7 +216,7 @@ module('Integration | Component | power-time-picker', function(hooks) {
 
   test('it resets search value on close', async function(assert) {
     await render(hbs`
-      <PowerTimePicker @selected={{time}} @steps=15 @onChange={{fn (mut time)}} as |time|>
+      <PowerTimePicker @selected={{this.time}} @steps={{15}} @onChange={{fn (mut this.time)}} as |time|>
         {{time}}
       </PowerTimePicker>
     `);
@@ -229,7 +229,7 @@ module('Integration | Component | power-time-picker', function(hooks) {
 
   test('it resets search input value on select', async function(assert) {
     await render(hbs`
-      <PowerTimePicker @selected={{time}} @steps=15 @onChange={{fn (mut time)}} as |time|>
+      <PowerTimePicker @selected={{this.time}} @steps={{15}} @onChange={{fn (mut this.time)}} as |time|>
         {{time}}
       </PowerTimePicker>
     `);


### PR DESCRIPTION
This fixes an issues where `minTime` and `maxTime` did not update if changed outside of this component, this was an unexpected usage which was why they were set statically. A test case has also been added to avoid this happening again.

Additionally the test files have had some lint fixes added.